### PR TITLE
Upgrade Helidon 4.2.0

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -2,5 +2,24 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <!-- For information see https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
 
+
+<!-- False Positive.
+     This is against an old version of prometheus (not prometheus metrics nor micrometer)
+ -->
+<suppress>
+   <notes><![CDATA[
+   file name: micrometer-registry-prometheus-simpleclient-1.13.4.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus-simpleclient@.*$</packageUrl>
+   <cve>CVE-2019-3826</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: prometheus-metrics-core-1.2.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.prometheus/prometheus-metrics-(.*)@.*$</packageUrl>
+   <cve>CVE-2019-3826</cve>
+</suppress>
+
 </suppressions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>4.0.6</version>
+        <version>4.2.0</version>
         <relativePath/>
     </parent>
     <groupId>io.helidon.samples</groupId>
@@ -47,10 +47,10 @@
         <version.lib.mockito>5.11.0</version.lib.mockito>
 
         <version.plugin.checkstyle>3.3.1</version.plugin.checkstyle>
-        <version.plugin.dependency-check>9.0.8</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.0</version.plugin.dependency-check>
         <version.plugin.directory>1.0</version.plugin.directory>
         <version.plugin.failsafe>3.2.5</version.plugin.failsafe>
-        <version.plugin.helidon-build-tools>4.0.6</version.plugin.helidon-build-tools>
+        <version.plugin.helidon-build-tools>4.0.16</version.plugin.helidon-build-tools>
         <version.plugin.jandex-maven-plugin>3.1.7</version.plugin.jandex-maven-plugin>
         <version.plugin.openapi-generator>6.2.1</version.plugin.openapi-generator>
         <version.plugin.spotbugs>4.8.5.0</version.plugin.spotbugs>


### PR DESCRIPTION
* Upgrades Helidon to 4.2.0
* Upgrade owasp dependency check plugin
* Suppresses a prometheus metrics false positive
